### PR TITLE
Update the way sphinx run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           pre-build-command: |
             python -m pip install --upgrade pip setuptools wheel
             pip install -U sphinx myst-parser
-          build-command: sphinx-build -n -b html docs/source build/html
+          build-command: sphinx-build -n -b html source ../build/html
       - uses: actions/upload-artifact@v1
         with:
           name: DocumentationHTML


### PR DESCRIPTION
The action to create the documentation only has a very old version of Sphinx that need update. This PR triggers this update manually and then uploads the documentation created as an artefact. If is it the master branch, also publish it to GitHub Pages. 