### PR TITLE
Create aliases for ThreadPool methods to simplify threads usage

### DIFF
--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock, patch
 
-from pytest import mark
+from pytest import mark, raises
 
 
 def test_thread_result():
@@ -132,3 +132,56 @@ class TestThreadPool:
             pool = ThreadPool(window)
             pool.post_event(None)
             WX.PostEvent.assert_called_once()
+
+
+def test_run_in_thread():
+    with patch("pyguitemp.threads.ThreadPool", MagicMock()):
+        from pyguitemp.threads import ThreadPool, run_in_thread
+
+        def target():
+            pass
+
+        run_in_thread(target)
+        assert ThreadPool().run_thread.call_count == 1
+        ThreadPool().run_thread.assert_called_once_with(target, None, None, None, None)
+
+
+def test_run_daemon():
+    with patch("pyguitemp.threads.ThreadPool", MagicMock()):
+        from pyguitemp.threads import ThreadPool, run_daemon
+
+        run_daemon(lambda: None)
+        ThreadPool().run_daemon_called_once_with(None, None, None, None, True)
+
+
+def test_abort_thread():
+    window = MagicMock()
+
+    class Worker:
+        ident = 123
+        abort = False
+        connect_events = MagicMock()
+        start = MagicMock()
+
+    with patch("pyguitemp.threads.WorkerThread", MagicMock(return_value=Worker)), patch(
+        "pyguitemp.threads.logger", MagicMock()
+    ):
+
+        from pyguitemp.threads import ThreadPool, abort_thread, logger, should_abort
+
+        pool = ThreadPool(window)
+        pool.run_thread(lambda: None)
+        abort_thread(123)
+        assert should_abort(123) is True
+
+        with raises(KeyError) as key_err:
+            abort_thread(124)
+        key_err_str = str(key_err.value)
+        assert "Thread with index: 124 is not in the ThreadPool." in key_err_str
+        assert logger.exception.call_count == 1
+
+        with raises(KeyError) as key_err:
+            should_abort(125)
+        key_err_str = str(key_err.value)
+        assert "Thread with index: 125 is not in the ThreadPool." in key_err_str
+        assert logger.exception.call_count == 2


### PR DESCRIPTION
Includes aliases for https://github.com/ImperialCollegeLondon/python-gui-template/blob/8481970b163899b5febb58752077ae088c166bb5/pyguitemp/threads.py#L109 methods in line with tasks in #38

Closes #38 